### PR TITLE
Allow users to set custom message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ You can override defaults in `.zshrc`:
 # If command execution time above min. time, plugins will not output time.
 ZSH_COMMAND_TIME_MIN_SECONDS=3
 
-# Set it to "" for disable echo `time: xx`.
-ZSH_COMMAND_TIME_ECHO=1
+# Message to display (set it to "" for disable).
+ZSH_COMMAND_TIME_MSG="Execution time: %s sec"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can override defaults in `.zshrc`:
 # If command execution time above min. time, plugins will not output time.
 ZSH_COMMAND_TIME_MIN_SECONDS=3
 
-# Message to display (set it to "" for disable).
+# Message to display (set to "" for disable).
 ZSH_COMMAND_TIME_MSG="Execution time: %s sec"
 ```
 

--- a/command-time.plugin.zsh
+++ b/command-time.plugin.zsh
@@ -1,5 +1,6 @@
 _command_time_preexec() {
   timer=${timer:-$SECONDS}
+  ZSH_COMMAND_TIME_MSG=${ZSH_COMMAND_TIME_MSG-"Time: %s"}
   export ZSH_COMMAND_TIME=""
 }
 
@@ -8,7 +9,7 @@ _command_time_precmd() {
     timer_show=$(($SECONDS - $timer))
     if [ -n "$TTY" ] && [ $timer_show -ge ${ZSH_COMMAND_TIME_MIN_SECONDS:-3} ]; then
       export ZSH_COMMAND_TIME="$timer_show"
-      if [ -n ${ZSH_COMMAND_TIME_ECHO+1} ] && [ -n "$ZSH_COMMAND_TIME_ECHO" ]; then
+      if [ ! -z ${ZSH_COMMAND_TIME_MSG} ]; then
         zsh_command_time
       fi
     fi
@@ -18,7 +19,7 @@ _command_time_precmd() {
 
 zsh_command_time() {
   if [ -n "$ZSH_COMMAND_TIME" ]; then
-    echo "time: $ZSH_COMMAND_TIME"
+    printf "${ZSH_COMMAND_TIME_MSG}\n" "$ZSH_COMMAND_TIME"
   fi
 }
 


### PR DESCRIPTION
Hi! 

Your plugin is great, I use it in all my computers... so thanks! but I think its a good idea to allow users to set a custom message...

For example, I prefer the text **_Execution time: 2 sec_** than just **_time: 2_**.

So, I changed the var `ZSH_COMMAND_TIME_ECHO` to `ZSH_COMMAND_TIME_MSG`.
You can set the var to display a custom text, set empty to display nothing or don't define the var to use your default text (_time: x_).

Thanks in advance,