### PR TITLE
fix: logic based on total seconds + colors configurable thresholds

### DIFF
--- a/command-time.plugin.zsh
+++ b/command-time.plugin.zsh
@@ -38,6 +38,7 @@ zsh_command_time() {
     typeset -i days=$(( ${ZSH_COMMAND_TIME} / 86400 ))
     typeset -i hours=$(( ${ZSH_COMMAND_TIME} / 3600 % 24 ))
     typeset -i min=$(( ${ZSH_COMMAND_TIME} / 60 % 60 ))
+    typeset -i total_sec=$(( ${ZSH_COMMAND_TIME} ))
     sec=$(( ZSH_COMMAND_TIME % 60 ))
     sec_fmt=$(printf '%d' "$sec")
     color="$ZSH_COMMAND_TIME_COLOR"
@@ -45,26 +46,25 @@ zsh_command_time() {
       # If SECONDS is a float, we limit the precision to 2 decimal places
       sec_fmt=$(printf '%02.2f' "$sec")
     fi
-    if [[ "$min" == 0 ]]; then
-        color="green"
+    if [[ "$total_sec" -lt 60 ]]; then # less than 1 minute
         timer_show="${sec_fmt}s"
-    elif [[ 1 -le "$min" && "$min" -le 3 ]]; then
-        color="yellow"
+    elif [[ "$total_sec" -lt 3600 ]]; then  # less than 1 hour
         timer_show="${min}m ${sec_fmt}s"
-    else
-        if [[ "$days" != 0 ]]; then
-            color="red"
-            timer_show="${days}d ${hours}h ${min}m ${sec_fmt}s"
-        elif [[ "$hours" != 0 ]]; then
-            color="red"
-            timer_show="${hours}h ${min}m ${sec_fmt}s"
-        else
-            color="red"
-            timer_show="${min}m ${sec_fmt}s"
-        fi
+    elif [[ "$days" -eq 0 ]]; then  # less than 1 day
+        timer_show="${hours}h ${min}m ${sec_fmt}s"
+    else # 1 day or more
+        timer_show="${days}d ${hours}h ${min}m ${sec_fmt}s"
     fi
     if [ -n "$ZSH_COMMAND_TIME_NO_COLOR" ]; then
       color="$ZSH_COMMAND_TIME_COLOR"
+    else
+        if [[ "$total_sec" -lt ${ZSH_COMMAND_TIME_SECONDS_GREEN:-60} ]]; then
+            color="green"
+        elif [[ "$total_sec" -lt ${ZSH_COMMAND_TIME_SECONDS_YELLOW:-180} ]]; then
+            color="yellow"
+        else
+            color="red"
+        fi
     fi
     print -P "%F{$ZSH_COMMAND_TIME_COLOR}$(printf "${ZSH_COMMAND_TIME_MSG}" "%F{$color}$timer_show")%f"
   fi


### PR DESCRIPTION
## Fix: logic based on total seconds + color configurable thresholds

### Bug

The original logic compares `$min` (minutes remainder) instead of total elapsed time. This means a command taking 1h 0m 30s shows as green (because `$min == 0`), while a command taking 3m 10s shows as red.

The root cause is using `$min` (which is `ZSH_COMMAND_TIME / 60 % 60`, the remainder) for thresholds that should be based on total duration.

### Changes

- Use `$total_sec` (total elapsed seconds) for both formatting and color logic, fixing incorrect color for durations >= 1 hour with 0 remaining minutes
- Simplify the conditionals using a clear cascade: `< 60s`, `< 1h`, `< 1d`, `>= 1d`
- Add configurable color thresholds via environment variables:
  - `ZSH_COMMAND_TIME_SECONDS_GREEN` — max seconds for green (default: 60)
  - `ZSH_COMMAND_TIME_SECONDS_YELLOW` — max seconds for yellow (default: 180)
- Respect `ZSH_COMMAND_TIME_NO_COLOR` to keep user-defined color when set

### Example

| Duration | Before | After |
|---|---|---|
| 30s | green | green |
| 2m 15s | yellow | yellow |
| 4m 0s | red | red |
| 1h 0m 30s | **green** (bug) | **red** (fixed) |
| 2h 15m 0s | **green** (bug) | **red** (fixed) |
